### PR TITLE
Fix Swoole package asset extension

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -113,7 +113,7 @@ jobs:
       - name: Download PHP Cli
         id: php_cli
         run: |
-          gh run download 3826528598 -R hyperf/lwmbs -n cli_static_${{ matrix.php-version }}_musl_${{ matrix.arch }}_ad4bf78451bf9894c4711694556132cc8f268ebf4a4607ba487984cdd338efad
+          gh run download 5471614657 -R hyperf/lwmbs -n cli_static_${{ matrix.php-version }}_musl_${{ matrix.arch }}_245a03ecd8971e80be6c5a88a947035278229272751ab84b382eafd735e9a2c
           ls -a
           chmod 755 ./php
 

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -113,7 +113,7 @@ jobs:
       - name: Download PHP Cli
         id: php_cli
         run: |
-          gh run download 5471614657 -R hyperf/lwmbs -n cli_static_${{ matrix.php-version }}_musl_${{ matrix.arch }}_245a03ecd8971e80be6c5a88a947035278229272751ab84b382eafd735e9a2c
+          gh run download 5471614657 -R hyperf/lwmbs -n cli_static_${{ matrix.php-version }}_musl_${{ matrix.arch }}_1245a03ecd8971e80be6c5a88a947035278229272751ab84b382eafd735e9a2c
           ls -a
           chmod 755 ./php
 

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Download PHP Cli
         id: php_cli
         run: |
-          gh run download 3826528598 -R hyperf/lwmbs -n cli_static_${{ matrix.php-version }}_musl_${{ matrix.arch }}_ad4bf78451bf9894c4711694556132cc8f268ebf4a4607ba487984cdd338efad
+          gh run download 5471614657 -R hyperf/lwmbs -n cli_static_${{ matrix.php-version }}_musl_${{ matrix.arch }}_1245a03ecd8971e80be6c5a88a947035278229272751ab84b382eafd735e9a2c
           ls -a
           chmod 755 ./php
 

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Download PHP Cli
         id: php_cli
         run: |
-          gh run download 3826528969 -R hyperf/lwmbs -n cli_${{ matrix.php-version }}_${{ matrix.arch }}_ad4bf78451bf9894c4711694556132cc8f268ebf4a4607ba487984cdd338efad
+          gh run download 6218236807 -R hyperf/lwmbs -n cli_${{ matrix.php-version }}_${{ matrix.arch }}_78ee8c86ed905c0569e22a6b2e2f46f25ec097c6ae2bfc53c8e790cf2d8c0b21
           chmod 755 ./php
 
       - name: Download Composer

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Download PHP Cli
         id: php_cli
         run: |
-          gh run download 3826529288 -R hyperf/lwmbs -n cli_${{ matrix.php-version }}_${{ matrix.arch }}_ad4bf78451bf9894c4711694556132cc8f268ebf4a4607ba487984cdd338efad
+          gh run download 6218251110 -R hyperf/lwmbs -n cli_${{ matrix.php-version }}_${{ matrix.arch }}_78ee8c86ed905c0569e22a6b2e2f46f25ec097c6ae2bfc53c8e790cf2d8c0b21
           ls -File
 
       - name: Download Composer

--- a/pkgs.json
+++ b/pkgs.json
@@ -95,7 +95,7 @@
         "release_asset_keyword": "swoole-cli",
         "release_asset_match_rule": {
             "Linux": "swoole-cli-${{version}}-linux-x64.tar.xz",
-            "Darwin": "swoole-cli-${{version}}-macos-x64.tar.gz"
+            "Darwin": "swoole-cli-${{version}}-macos-x64.tar.xz"
         }
     }
 }


### PR DESCRIPTION
Fixes:
```
Download url is empty, maybe the url parse failed.
```
When run:
```
box get swoole-cli
```